### PR TITLE
docs(react-native): correct the Expo Go claim (blocks release)

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -22,7 +22,7 @@ import SkiaChart, { SkiaRenderer } from "@wuba/react-native-echarts/skiaChart";
 />;
 ```
 
-**Expo:** these are native modules, so they need a [development build](https://docs.expo.dev/develop/development-builds/introduction/) — they don't run in Expo Go. If you'd rather not leave Expo Go, use the WebView embed instead (see below).
+**Expo:** all three are on Expo's [supported-in-Expo Go](https://docs.expo.dev/versions/latest/sdk/third-party-overview/) list, so no development build is needed. This package itself is plain JavaScript — the native code is all theirs.
 
 ## Why you pass `chart` and `renderer`
 
@@ -124,7 +124,7 @@ A mismatched or missing `renderer` surfaces here too, as `Renderer '…' is not 
 
 ## The WebView alternative
 
-If you'd rather not add native modules — or you need to stay in Expo Go — the hosted graph works in a web view with no packages at all:
+If you'd rather not add a charting library at all, the hosted graph works in a web view:
 
 ```jsx
 import { WebView } from "react-native-webview";


### PR DESCRIPTION
**Blocks the first `terra-graphs-react-native` release** — the README is baked into the npm tarball, so publishing before this ships the error permanently.

#6 merged just before this correction landed on its branch, so main still carries the wrong claim.

## The claim

> these are native modules, so they need a development build — they don't run in Expo Go

That is the opposite of the truth:

- **`@wuba/react-native-echarts` ships no native code.** No podspec, no `build.gradle`, no `.java` / `.kt` / `.m` / `.h` — it is plain JavaScript. So is our package.
- **All three modules it peers on are in Expo Go.** `@shopify/react-native-skia`, `react-native-svg` and `react-native-gesture-handler` are all on [Expo's supported-in-Expo-Go list](https://docs.expo.dev/versions/latest/sdk/third-party-overview/).

So an Expo Go user needed no development build, and the README was sending them to the WebView for nothing — the one thing this package exists to avoid.

## Confidence

Inferred from Expo's own compatibility list plus the contents of the wuba package, **not from a device**. That is the same caveat as everything else runtime in this package, and part of what the pre-release device spike should confirm.

If it turns out Expo Go's bundled Skia build is missing something wuba needs, the correction is a one-line revert — and better to find that on a phone than to keep shipping a claim we know to be wrong on the evidence we have.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tryterra/codesmith/terra-graphs/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755807&installation_model_id=431345&pr_number=7&repository=tryterra%2Fterra-graphs&return_to=https%3A%2F%2Fgithub.com%2Ftryterra%2Fterra-graphs%2Fpull%2F7&signature=b9acd7dd38f8db068b339249e056e8ea5028a8978c2140f1ea6678dadfca6d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->