### PR TITLE
feat(react-native): bundle the chart engine so installs need no config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3587,6 +3587,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@wuba/react-native-echarts/-/react-native-echarts-3.1.1.tgz",
       "integrity": "sha512-1FcKeBBSzJhdQzT7Uwh+WG8+hnLOneVjVHRY1/fjc+7iMHHPZ0dWnlmOuatRhRZzIvLbaAxF94Tsegcy1G44+Q==",
+      "dev": true,
       "license": "MIT",
       "workspaces": [
         "example"
@@ -3619,6 +3620,7 @@
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
       "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3963,6 +3965,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
@@ -4379,6 +4388,60 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4422,23 +4485,74 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/echarts": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
       "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.6.0"
-      }
-    },
-    "node_modules/echarts/node_modules/zrender": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tslib": "2.3.0"
       }
     },
     "node_modules/ee-first": {
@@ -4466,6 +4580,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -5638,6 +5765,13 @@
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -6255,6 +6389,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nullthrows": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
@@ -6806,6 +6953,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.15.5",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.5.tgz",
+      "integrity": "sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
@@ -8412,11 +8574,11 @@
       }
     },
     "node_modules/zrender": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
-      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+      "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -8441,21 +8603,19 @@
       "name": "@tryterra/graphs-react-native",
       "version": "0.1.0",
       "license": "MIT",
-      "dependencies": {
-        "echarts": "5.5.1"
+      "devDependencies": {
+        "@wuba/react-native-echarts": "3.1.1",
+        "echarts": "5.5.1",
+        "zrender": "5.6.0"
       },
       "peerDependencies": {
         "@shopify/react-native-skia": "*",
-        "@wuba/react-native-echarts": ">=3",
         "react": ">=17",
         "react-native": ">=0.70",
-        "react-native-svg": "*"
+        "react-native-svg": ">=13"
       },
       "peerDependenciesMeta": {
         "@shopify/react-native-skia": {
-          "optional": true
-        },
-        "react-native-svg": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   "allowScripts": {
     "esbuild@0.27.7": true,
     "esbuild@0.28.2": true
+  },
+  "overrides": {
+    "zrender": "5.6.0"
   }
 }

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -5,41 +5,73 @@ Embed a Terra graph in a React Native app, drawn natively — no WebView.
 You design the graph in the [Terra dashboard](https://dashboard.tryterra.co/dashboard/graphs): pick the metric, the chart type, the colours, the header stats. This component renders it, for one user, as native views.
 
 ```bash
-npm install @tryterra/graphs-react-native @wuba/react-native-echarts @shopify/react-native-skia react-native-gesture-handler
+npm install @tryterra/graphs-react-native
 ```
 
 ```jsx
 import { TerraGraph } from "@tryterra/graphs-react-native";
-import SkiaChart, { SkiaRenderer } from "@wuba/react-native-echarts/skiaChart";
 
 <TerraGraph
   sessionId="a1b2c3d4-0000-0000-0000-000000000000"
   userId={terraUserId}
   timeframe={30}
-  chart={SkiaChart}
-  renderer={SkiaRenderer}
   height={240}
 />;
 ```
 
-**Expo:** all three are on Expo's [supported-in-Expo Go](https://docs.expo.dev/versions/latest/sdk/third-party-overview/) list, so no development build is needed. This package itself is plain JavaScript — the native code is all theirs.
+That is the whole setup. No Metro config, no `overrides` entry, no chart engine to
+install or wire up.
 
-## Why you pass `chart` and `renderer`
+`react-native-svg` is the one thing this needs that it cannot bundle — it is a
+native module, and React Native has no drawing surface of its own. It is declared
+as a peer, so npm installs it for you.
 
-The painter is yours to choose, and you import both halves of it so your app links only the native module it actually uses. They always come as a pair from the same entry point:
+**Expo:** run `npx expo install react-native-svg` once afterwards. npm resolves the
+newest release; `expo install` pins the one matching your SDK. Both are in Expo Go,
+so no development build is needed.
 
-| Painter | Install | Import |
-| --- | --- | --- |
-| **Skia** (recommended) | `@shopify/react-native-skia` | `SkiaChart, { SkiaRenderer }` from `@wuba/react-native-echarts/skiaChart` |
-| **SVG** | `react-native-svg` | `SvgChart, { SVGRenderer }` from `@wuba/react-native-echarts/svgChart` |
+## Using Skia instead
 
-```jsx
-import SvgChart, { SVGRenderer } from "@wuba/react-native-echarts/svgChart";
+Skia paints faster on very dense charts. It costs two extra native modules —
+`react-native-reanimated` and `react-native-worklets`, which Skia peer-requires and
+throws without — so it is opt-in rather than the default:
 
-<TerraGraph sessionId={s} userId={u} chart={SvgChart} renderer={SVGRenderer} />;
+```bash
+npm install @tryterra/graphs-react-native @shopify/react-native-skia react-native-reanimated
 ```
 
-If the component imported them itself, every app would carry Skia *and* react-native-svg. Both are needed because ECharts draws through a painter the renderer registers, and the chart view is what it paints into — passing one without the other leaves nothing to draw with.
+```jsx
+import { TerraGraph } from "@tryterra/graphs-react-native/skia";
+```
+
+Same component, same props. The chart engine sits in a shared chunk, so importing
+both entries costs one engine and two painters — not two of each.
+
+## Why the chart engine is bundled
+
+Unusually for a React Native library, this package ships ECharts, zrender and the
+painter *inside* `dist/` instead of listing them as dependencies. Two reasons,
+both of which cost users a broken app otherwise:
+
+- **tslib.** Every ECharts and zrender release, up to and including 6.1.0, pins
+  `tslib` to exactly 2.3.0. That version's `exports` map resolves to an ES module
+  which Metro then hands to a CommonJS `require`, so the app bundles cleanly and
+  crashes on launch with `Cannot read property '__extends' of undefined`. Bundling
+  resolves tslib at *our* build time, on Node, where the interop is correct.
+- **One zrender.** The painter registers itself into zrender's module-level
+  instance registry. If the copy it registers into is not the copy ECharts draws
+  through, `init` succeeds, `setOption` succeeds, and the chart renders blank with
+  no error at all. Shipping one bundle makes that failure impossible rather than
+  merely unlikely.
+
+The trade is about 271 KB gzipped in your app bundle for the default entry, or
+241 KB for the Skia one (measured minified + gzipped, as a release build ships
+them). That is roughly what these libraries would have cost as ordinary
+dependencies, since it is the same code. If your app
+*already* uses ECharts directly you will now carry two copies; tell us and we will
+add a build that externalises it.
+
+Licences for the bundled code are in [THIRD-PARTY-NOTICES.md](./THIRD-PARTY-NOTICES.md).
 
 ## Props
 
@@ -47,8 +79,6 @@ If the component imported them itself, every app would carry Skia *and* react-na
 | --- | --- | --- |
 | `sessionId` | `string` | **Required.** The graph, from the dashboard. |
 | `userId` | `string` | **Required.** The Terra user to render, or `"example"`. |
-| `chart` | component | **Required.** `SkiaChart` or `SvgChart` (above). |
-| `renderer` | — | **Required.** The matching `SkiaRenderer` or `SVGRenderer`. |
 | `timeframe` | `number` | Days back from today, including today. Defaults to 7. |
 | `from`, `to` | `IsoDate` | `YYYY-MM-DD` (UTC). `to` is inclusive. |
 | `baseUrl` | `string` | Graph API base. Defaults to `https://api.tryterra.co/v2`. |
@@ -70,8 +100,6 @@ import { toIsoDate } from "@tryterra/graphs-react-native";
 <TerraGraph
   sessionId={s}
   userId={u}
-  chart={SkiaChart}
-  renderer={SkiaRenderer}
   from={toIsoDate(picked)}
   to={toIsoDate(until)}
 />;
@@ -98,8 +126,6 @@ const scheme = useColorScheme();
 <TerraGraph
   sessionId={s}
   userId={u}
-  chart={SkiaChart}
-  renderer={SkiaRenderer}
   theme={scheme === "dark" ? { bg: "#0F172A", text: "#E2E8F0", line: "#38BDF8" } : undefined}
 />;
 ```
@@ -114,13 +140,9 @@ Give colours as hex (`#38BDF8`, `#3BF`) or `rgb()`/`rgba()`. Named colours and `
 <TerraGraph
   sessionId={s}
   userId={u}
-  chart={SkiaChart}
-  renderer={SkiaRenderer}
   onError={(error) => reportToSentry(error, { traceId: error.traceId })}
 />
 ```
-
-A mismatched or missing `renderer` surfaces here too, as `Renderer '…' is not imported` — the most common setup mistake, reported through the card rather than as an unhandled exception.
 
 ## The WebView alternative
 
@@ -153,8 +175,11 @@ and the chart-option builder — for building your own chart surface:
 import { fetchPayload, buildChartOption } from "@tryterra/graphs-react-native/core";
 
 const payload = await fetchPayload({ sessionId, userId, timeframe: 30 });
-const option = buildChartOption(payload, { echarts });
+const option = buildChartOption(payload, { echarts }); // your own echarts instance
 ```
+
+`core` deliberately holds no chart engine, so it stays small and runs under plain
+Node. Pass in whichever `echarts` you are driving.
 
 ## Docs
 

--- a/packages/react-native/THIRD-PARTY-NOTICES.md
+++ b/packages/react-native/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,537 @@
+# Third-party notices
+
+`@tryterra/graphs-react-native` bundles its chart engine into `dist/` rather than
+resolving it from the host app. That makes the following projects part of the
+published artifact, and their licences are reproduced here in full as those
+licences require.
+
+## echarts 5.5.1
+
+Declared licence: `Apache-2.0`.
+
+<https://echarts.apache.org>
+
+### NOTICE
+
+```
+Apache ECharts
+Copyright 2017-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+```
+
+```
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+
+
+========================================================================
+Apache ECharts Subcomponents:
+
+The Apache ECharts project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for these
+subcomponents is also subject to the terms and conditions of the following
+licenses.
+
+BSD 3-Clause (d3.js):
+The following files embed [d3.js](https://github.com/d3/d3) BSD 3-Clause:
+    `/src/chart/treemap/treemapLayout.ts`,
+    `/src/chart/tree/layoutHelper.ts`,
+    `/src/chart/graph/forceHelper.ts`,
+    `/src/util/number.ts`
+See `/licenses/LICENSE-d3` for details of the license.
+```
+
+---
+
+## zrender 5.6.0
+
+Declared licence: `BSD-3-Clause`.
+
+```
+BSD 3-Clause License
+
+Copyright (c) 2017, Baidu Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## @wuba/react-native-echarts 3.1.1
+
+Declared licence: `MIT`.
+
+<http://github.com/wuba/react-native-echarts#readme>
+
+```
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+
+
+
+========================================================================
+This product bundles various third-party components under other open source licenses.
+This section summarizes those components and their licenses. See licenses/
+for text of these licenses.
+
+BSD 3-Clause
+--------------------------------------
+
+src/utils/platform.ts
+src/SVGCore.ts
+```
+
+---
+
+## tslib 2.3.0
+
+Declared licence: `0BSD`.
+
+<https://www.typescriptlang.org/>
+
+```
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+```
+
+---

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -24,50 +24,51 @@
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "./package.json": "./package.json",
+    "./skia": {
+      "types": "./dist/skia.d.ts",
+      "default": "./dist/skia.js"
+    },
     "./core": {
       "types": "./dist/core.d.ts",
-      "import": "./dist/core.js",
-      "require": "./dist/core.cjs"
-    }
+      "default": "./dist/core.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "THIRD-PARTY-NOTICES.md"
   ],
   "scripts": {
     "extract": "node scripts/extract-option-builder.mjs",
     "build": "tsup",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {
-    "echarts": "5.5.1"
-  },
   "peerDependencies": {
     "@shopify/react-native-skia": "*",
-    "@wuba/react-native-echarts": ">=3",
     "react": ">=17",
     "react-native": ">=0.70",
-    "react-native-svg": "*"
+    "react-native-svg": ">=13"
   },
   "peerDependenciesMeta": {
     "@shopify/react-native-skia": {
-      "optional": true
-    },
-    "react-native-svg": {
       "optional": true
     }
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@wuba/react-native-echarts": "3.1.1",
+    "echarts": "5.5.1",
+    "zrender": "5.6.0"
   }
 }

--- a/packages/react-native/src/TerraGraph.tsx
+++ b/packages/react-native/src/TerraGraph.tsx
@@ -31,6 +31,7 @@ import {
 } from "echarts/components";
 
 import { buildChartOption } from "./option-builder.js";
+import { plainTextTooltips } from "./tooltip";
 import { Header } from "./Header";
 import { SleepStages } from "./SleepStages";
 import { fetchPayload, type GraphSource } from "./payload";
@@ -199,7 +200,9 @@ export function TerraGraph({
         height,
       } as never);
       instance.setOption(
-        buildChartOption(payload, { echarts, theme: themeRef.current, fontFamily: "System" }),
+        plainTextTooltips(
+          buildChartOption(payload, { echarts, theme: themeRef.current, fontFamily: "System" }),
+        ),
         {
           notMerge: true,
         },
@@ -244,9 +247,15 @@ export function TerraGraph({
     <View style={[styles.card, { backgroundColor: background }, style]} onLayout={onLayout}>
       <Header payload={payload} theme={theme} />
       {/* Only the Skia view takes width/height props; the SVG one reads them
-          from the init options and its own style, so pass both. */}
+          from the init options and its own style, so pass both.
+
+          Deliberately not `useRNGH`: that switches the chart's touch handling to
+          react-native-gesture-handler, which then requires the whole app to sit
+          inside a GestureHandlerRootView and throws if it doesn't. The default
+          PanResponder path needs no such setup and drives tooltips fine, including
+          inside a ScrollView. */}
       {width > 0 && (
-        <ChartView ref={chartRef as never} useRNGH style={{ width, height }} width={width} height={height} />
+        <ChartView ref={chartRef as never} style={{ width, height }} width={width} height={height} />
       )}
       {payload.kind === "sleep" && <SleepStages payload={payload} theme={theme} />}
     </View>

--- a/packages/react-native/src/core.ts
+++ b/packages/react-native/src/core.ts
@@ -12,3 +12,4 @@ export { DEFAULT_BASE_URL, fetchPayload, payloadUrl, type GraphSource } from "./
 export { formatDuration, headerStats, statFmt, type StatColumn } from "./stats";
 export { TerraGraphError, toIsoDate, type GraphPayload, type GraphTheme, type IsoDate } from "./types";
 export { buildChartOption } from "./option-builder.js";
+export { plainTextTooltips, toPlainText } from "./tooltip";

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,5 +1,0 @@
-export { TerraGraph, type TerraGraphProps } from "./TerraGraph";
-// The React-Native-free half is also published as
-// `@tryterra/graphs-react-native/core`, for custom chart surfaces and so it can be
-// tested under plain Node.
-export * from "./core";

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * The default build: `<TerraGraph sessionId userId />`, drawn with
+ * react-native-svg.
+ *
+ * React Native has no drawing surface of its own — no canvas, and ART was
+ * removed from core — so a chart needs exactly one native module to paint into.
+ * This entry picks the cheapest one: react-native-svg needs only React and
+ * React Native, where Skia additionally drags in Reanimated and Worklets.
+ * `@tryterra/graphs-react-native/skia` is there for apps that want Skia anyway.
+ *
+ * ECharts, zrender and the painter are bundled into this file rather than
+ * resolved from the app's node_modules. That is not a packaging preference, it
+ * is what makes the component installable:
+ *
+ *  - ECharts pins `tslib` to 2.3.0, whose package entry points resolve, under
+ *    Metro, to an ES module handed to a CommonJS `require`. Bundling resolves
+ *    tslib here instead, on Node, where that interop is correct.
+ *  - The painter registers itself into zrender's module-level instance registry.
+ *    If the app's zrender is a different copy from the one ECharts draws
+ *    through, the chart initialises, reports success, and paints nothing.
+ *    One bundle means one zrender, by construction.
+ *
+ * Import whichever entry you want; the chart engine lives in a shared chunk, so
+ * importing both costs one engine and two painters, not two of each.
+ */
+import SvgChart, { SVGRenderer } from "@wuba/react-native-echarts/svgChart";
+
+import { TerraGraph as Base, type TerraGraphProps as BaseProps } from "./TerraGraph";
+
+/** Props for `<TerraGraph>`. The painter is built in, so there is none to pass. */
+export type TerraGraphProps = Omit<BaseProps, "chart" | "renderer">;
+
+/** A Terra graph, drawn with react-native-svg. */
+export function TerraGraph(props: TerraGraphProps) {
+  return <Base {...props} chart={SvgChart} renderer={SVGRenderer} />;
+}
+
+// The React-Native-free half is also published as
+// `@tryterra/graphs-react-native/core`, for custom chart surfaces and so it can be
+// tested under plain Node.
+export * from "./core";

--- a/packages/react-native/src/skia.tsx
+++ b/packages/react-native/src/skia.tsx
@@ -1,0 +1,26 @@
+/**
+ * The Skia build, for apps that already carry `@shopify/react-native-skia` or
+ * want its faster painting for very dense charts. Identical component and props
+ * to the default entry — only the painter differs. See `./index.tsx` for why the
+ * chart engine is bundled.
+ *
+ * Costs two more native modules than the default: Skia peer-requires
+ * `react-native-reanimated` and `react-native-worklets`, and throws on first
+ * render without them.
+ *
+ * The chart engine is a shared chunk, so importing this alongside the default
+ * entry costs one engine and two painters rather than two of each.
+ */
+import SkiaChart, { SkiaRenderer } from "@wuba/react-native-echarts/skiaChart";
+
+import { TerraGraph as Base, type TerraGraphProps as BaseProps } from "./TerraGraph";
+
+/** Props for `<TerraGraph>`. The painter is built in, so there is none to pass. */
+export type TerraGraphProps = Omit<BaseProps, "chart" | "renderer">;
+
+/** A Terra graph, drawn with Skia. */
+export function TerraGraph(props: TerraGraphProps) {
+  return <Base {...props} chart={SkiaChart} renderer={SkiaRenderer} />;
+}
+
+export * from "./core";

--- a/packages/react-native/src/tooltip.ts
+++ b/packages/react-native/src/tooltip.ts
@@ -1,0 +1,79 @@
+/**
+ * Flatten the builder's tooltip markup to text.
+ *
+ * The option builder is shared with the web renderer, where a tooltip is a DOM
+ * node and its formatter returns HTML. Skia and SVG have no DOM: ECharts draws
+ * whatever string it gets, so the markup renders verbatim — a tooltip reading
+ * `;font-size:11px'>Aug 8</div>`. Rewriting the formatters upstream would mean
+ * the web renderer losing its styling, so the flattening happens here, on the
+ * built option, and only on this platform.
+ */
+
+/** Entities the builder's formatters can emit. Not a general HTML decoder. */
+const ENTITIES: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+};
+
+/**
+ * Text of an HTML fragment, with block boundaries kept as newlines so a
+ * multi-line tooltip stays multi-line.
+ */
+export function toPlainText(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(?:div|p|tr)>/gi, "\n")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&[a-z]+;|&#\d+;/gi, (e) => ENTITIES[e.toLowerCase()] ?? e)
+    .replace(/[ \t]+/g, " ")
+    .replace(/ *\n+ */g, "\n")
+    .trim();
+}
+
+/** Marks a formatter this module already wrapped, so a re-walk can't double-wrap. */
+const WRAPPED = Symbol.for("terra.plainTooltip");
+
+type Formatter = ((...args: unknown[]) => unknown) & { [WRAPPED]?: true };
+
+/**
+ * Wrap every `tooltip.formatter` in the option so its result is plain text.
+ *
+ * Tooltips are configured at the root and per series, and the sleep and macro
+ * charts add their own, so this walks rather than naming the known sites — a
+ * new decoration in the shared builder shouldn't reintroduce raw markup here.
+ * Mutates in place: the option was just built for this render and is not shared.
+ */
+export function plainTextTooltips<T>(option: T): T {
+  const seen = new Set<unknown>();
+
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== "object" || seen.has(node)) return;
+    seen.add(node);
+
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+
+    const record = node as Record<string, unknown>;
+    const tip = record.tooltip as { formatter?: Formatter } | undefined;
+    const inner = tip?.formatter;
+    if (typeof inner === "function" && !inner[WRAPPED]) {
+      const wrapped: Formatter = (...args: unknown[]) => {
+        const out = inner(...args);
+        return typeof out === "string" ? toPlainText(out) : out;
+      };
+      wrapped[WRAPPED] = true;
+      tip!.formatter = wrapped;
+    }
+
+    Object.values(record).forEach(visit);
+  };
+
+  visit(option);
+  return option;
+}

--- a/packages/react-native/tsup.config.ts
+++ b/packages/react-native/tsup.config.ts
@@ -1,22 +1,21 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/core.ts"],
-  format: ["esm", "cjs"],
+  entry: ["src/index.tsx", "src/skia.tsx", "src/core.ts"],
+  // ESM only. Code splitting is what keeps the two painter entries from each
+  // carrying their own copy of ECharts, and esbuild cannot split CommonJS.
+  // Metro resolves ESM from a dependency without help.
+  format: ["esm"],
+  splitting: true,
   dts: true,
   clean: true,
   target: "es2020",
-  // Everything with a native half, plus echarts, stays external: the app links
-  // one copy through its own resolution rather than carrying ours.
-  external: [
-    "react",
-    "react-native",
-    "echarts",
-    "echarts/core",
-    "echarts/charts",
-    "echarts/components",
-    "@wuba/react-native-echarts",
-    "@shopify/react-native-skia",
-    "react-native-svg",
-  ],
+  // The chart engine ships *inside* this package. Bundling it is load-bearing,
+  // not a size preference — see the comment at the top of src/index.tsx. The
+  // short version: it is the only way to get correct tslib interop under Metro
+  // without asking every app for a package.json override, and the only way to
+  // guarantee the painter and ECharts share one zrender.
+  noExternal: ["echarts", "zrender", "@wuba/react-native-echarts"],
+  // Anything with a native half stays the app's to install and link.
+  external: ["react", "react-native", "@shopify/react-native-skia", "react-native-svg"],
 });

--- a/test/bundle.test.mjs
+++ b/test/bundle.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * Guards on the *built* React Native bundle.
+ *
+ * Both invariants here fail silently at runtime, which is why they are asserted
+ * against the artifact rather than left to review:
+ *
+ *  - A surviving `tslib` import means the app crashes on launch under Metro
+ *    ("Cannot read property '__extends' of undefined"), because Metro resolves
+ *    tslib 2.3.0's exports map to an ES module and hands it to a `require`.
+ *  - A second zrender copy means the painter registers into an instance ECharts
+ *    does not draw through. `init` succeeds, `setOption` succeeds, `onLoad`
+ *    fires, and the chart is blank. Nothing throws. This has happened twice.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const DIST = fileURLToPath(new URL("../packages/react-native/dist/", import.meta.url));
+const js = () => readdirSync(DIST).filter((f) => f.endsWith(".js"));
+const read = (f) => readFileSync(DIST + f, "utf8");
+
+test("the bundle carries no tslib import", () => {
+  const files = js();
+  assert.ok(files.length > 0, "dist is empty — did the build run?");
+  for (const f of files) {
+    assert.doesNotMatch(
+      read(f),
+      /(?:from|require\()\s*["']tslib["']/,
+      `${f} imports tslib; Metro will resolve it to the wrong module format and the app will crash on launch`,
+    );
+  }
+});
+
+test("exactly one zrender is bundled", () => {
+  const all = js().map(read).join("\n");
+
+  // zrender's module-level instance registry. One declaration per copy; esbuild
+  // renames the second to painterCtors2, which is the tell.
+  const registries = all.match(/^var painterCtors\d* = \{\}/gm) ?? [];
+  assert.equal(
+    registries.length,
+    1,
+    `found ${registries.length} zrender instance registries (${registries.join(", ")}) — ` +
+      "the painter and ECharts must share one zrender or every chart renders blank",
+  );
+
+  const paths = new Set((all.match(/^\/\/ .*zrender\/lib\/zrender\.js$/gm) ?? []).map((s) => s.trim()));
+  assert.equal(paths.size, 1, `zrender resolved from ${paths.size} paths: ${[...paths].join(", ")}`);
+});
+
+test("each painter entry pulls only its own native module", () => {
+  assert.doesNotMatch(
+    read("skia.js"),
+    /react-native-svg/,
+    "the Skia entry must not drag in react-native-svg",
+  );
+  assert.doesNotMatch(
+    read("index.js"),
+    /@shopify\/react-native-skia/,
+    "the default (SVG) entry must not drag in Skia",
+  );
+});
+
+test("nothing but native modules is left for the app to resolve", () => {
+  const allowed = new Set([
+    "react",
+    "react/jsx-runtime",
+    "react-native",
+    "@shopify/react-native-skia",
+    "react-native-svg",
+  ]);
+  // Anchored at a line-leading `import`, so a bare string inside ECharts that
+  // happens to follow the word "from" is not mistaken for a dependency.
+  const IMPORTS = /^import\s(?:[^;"]*?from\s*)?"([^"]+)"/gm;
+
+  let checked = 0;
+  for (const f of js()) {
+    for (const m of read(f).matchAll(IMPORTS)) {
+      const spec = m[1];
+      if (spec.startsWith("./") || spec.startsWith("../")) continue;
+      checked++;
+      assert.ok(
+        allowed.has(spec),
+        `${f} expects the app to provide "${spec}"; only native modules may stay external`,
+      );
+    }
+  }
+  assert.ok(checked > 0, "no bare imports found at all — the matcher is broken, not the bundle");
+});

--- a/test/tooltip.test.mjs
+++ b/test/tooltip.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Tooltips on React Native must be plain text.
+ *
+ * The option builder is shared with the web renderer and its tooltip formatters
+ * return HTML. Skia and SVG draw the string as-is, so before this was flattened
+ * a tooltip on device read `;font-size:11px;margin-top:1px'>Aug 8</div>`.
+ *
+ * The real fixtures are exercised through the builder rather than hand-written
+ * markup, so a new decoration that emits tags is caught here too.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import * as echarts from "echarts";
+
+import { plainTextTooltips, toPlainText } from "@tryterra/graphs-react-native/core";
+import { buildChartOption } from "../packages/react-native/src/option-builder.js";
+
+const FIXTURES = fileURLToPath(new URL("../packages/react-native/test/fixtures/", import.meta.url));
+const THEME = { bg: "#fff", line: "#3b82f6", text: "#111", tick: "#999" };
+
+test("markup becomes text, block boundaries become newlines", () => {
+  assert.equal(
+    toPlainText("<div style='font-weight:600'>3,415 <span style='opacity:.55'>steps</span></div>"),
+    "3,415 steps",
+  );
+  assert.equal(toPlainText("<div>a</div><div>b</div>"), "a\nb");
+  assert.equal(toPlainText("one<br>two"), "one\ntwo");
+  assert.equal(toPlainText("5&nbsp;&amp;&nbsp;6"), "5 & 6");
+  // The exact shape that shipped broken: an attribute fragment must not survive.
+  assert.equal(toPlainText("<div style='font-size:11px;margin-top:1px'>Aug 8</div>"), "Aug 8");
+});
+
+test("wrapping is idempotent", () => {
+  const option = { tooltip: { formatter: () => "<b>x</b>" } };
+  plainTextTooltips(plainTextTooltips(option));
+  assert.equal(option.tooltip.formatter(), "x");
+});
+
+test("a non-string formatter result is passed through untouched", () => {
+  const node = {};
+  const option = { tooltip: { formatter: () => node } };
+  plainTextTooltips(option);
+  assert.equal(option.tooltip.formatter(), node);
+});
+
+test("no fixture's tooltip emits markup once flattened", (t) => {
+  const files = readdirSync(FIXTURES).filter((f) => f.endsWith(".json"));
+  assert.ok(files.length > 0, "no fixtures found");
+
+  let checked = 0;
+  for (const file of files) {
+    const payload = JSON.parse(readFileSync(FIXTURES + file, "utf8"));
+    const option = plainTextTooltips(
+      buildChartOption(payload, { echarts, theme: THEME, fontFamily: "System" }),
+    );
+
+    // Params shaped as ECharts hands them to an axis-trigger formatter.
+    const params = (payload.series ?? []).map((s, i) => ({
+      seriesName: s.name,
+      seriesIndex: i,
+      name: payload.labels?.[0] ?? "2026-08-08",
+      axisValue: payload.labels?.[0] ?? "2026-08-08",
+      axisValueLabel: payload.labels?.[0] ?? "2026-08-08",
+      value: s.values?.[0] ?? 1,
+      data: s.values?.[0] ?? 1,
+      marker: "<span style='display:inline-block;width:9px'></span>",
+      dataIndex: 0,
+      color: "#3b82f6",
+    }));
+    if (!params.length) continue;
+
+    const formatter = option?.tooltip?.formatter;
+    if (typeof formatter !== "function") continue;
+
+    let out;
+    try {
+      out = formatter(params);
+    } catch {
+      // A formatter that needs richer params than this harness builds is not
+      // what this test is about; the markup check below covers the rest.
+      continue;
+    }
+    if (typeof out !== "string") continue;
+
+    checked++;
+    assert.doesNotMatch(out, /<[a-z/][^>]*>/i, `${file}: tooltip still contains markup: ${out}`);
+    assert.doesNotMatch(out, /style\s*=|font-size:|margin-top:/i, `${file}: tooltip leaked CSS: ${out}`);
+  }
+
+  assert.ok(checked > 0, "no fixture produced a string tooltip — the test proved nothing");
+  t.diagnostic(`${checked} fixture tooltips flattened`);
+});


### PR DESCRIPTION
`npm install @tryterra/graphs-react-native` is now the whole setup — no `overrides`, no `metro.config.js`, no chart engine to wire up. Verified on an iOS device with a clean tree containing none of echarts, zrender, @wuba or tslib.

A device run found three defects that no Node test could reach, because all three live in the consumer's module resolution:

- **tslib.** ECharts and zrender pin it to exactly 2.3.0 in every release through 6.1.0. Metro resolves that version's `exports` map to an ES module and hands it to a CommonJS `require`, so the app bundles cleanly and crashes on launch with `Cannot read property '__extends' of undefined`. The `overrides` workaround we had documented turns out to be **npm-only** — pnpm ignores it and yarn wants `resolutions` — so it silently no-opped for most users.
- **Duplicate zrender.** @wuba declares echarts and zrender as `*` peers, so npm was free to hand the painter a different zrender from the one ECharts draws through. `init` succeeds, `setOption` succeeds, `onLoad` fires, and the chart is blank with nothing thrown.
- **`useRNGH`.** We opted into gesture-handler, which throws unless the whole app sits inside a `GestureHandlerRootView`.

Bundling the engine into `dist/` removes all three by construction: tslib resolves at build time on Node, where the interop is correct, and one bundle can hold only one zrender.

**Packaging.** The default entry draws with `react-native-svg`, which needs only React and React Native; Skia moves to `/skia` because it also pulls in Reanimated and Worklets. `react-native-svg` is a required peer, so npm installs it unprompted. `chart` and `renderer` are gone from the public API — they were the last way a caller could hand us a painter built against their own zrender.

**Guards.** Both silent failure modes are asserted against the built bundle (no tslib import, exactly one zrender, entries don't cross-import native modules), since neither produces a runtime error. Mutation-tested.

Tooltips are flattened to plain text here: the option builder is shared with the web renderer, whose formatters return HTML for a DOM tooltip, and Skia and SVG drew the markup verbatim.

### Costs, stated plainly

- ~271 KB gzipped for the default entry, 241 KB for Skia — roughly what these libraries cost as ordinary dependencies, since it is the same code.
- No Dependabot or `npm audit` coverage on the bundled engine. This is the sharpest downside and wants an owner.
- Apps already using ECharts carry two copies, with no dedupe possible now the injection props are gone. A `/bring-your-own` entry would fix it in ~10 lines, on request.
- Pinned to ECharts 5.5.1 + zrender 5.6.0 for everyone.
- react-native-web would get @wuba's native variant rather than its `.web.tsx`.

Licences for the bundled code are in `THIRD-PARTY-NOTICES.md` (Apache-2.0, BSD-3-Clause, MIT, 0BSD). Note that `@wuba`'s package.json declares MIT while its LICENSE file is Apache-2.0 — worth a glance before publishing.

The package is still unpublished, so none of this breaks anyone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tryterra/codesmith/terra-graphs/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789832985&installation_model_id=431345&pr_number=8&repository=tryterra%2Fterra-graphs&return_to=https%3A%2F%2Fgithub.com%2Ftryterra%2Fterra-graphs%2Fpull%2F8&signature=3990d4ff9f41326d81a1e71a4e73a2e1a4463054f2d54af7fe1ebe15f312721b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->