### PR TITLE
ci: catch renderer drift, and derive the licence notices from the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
       - run: npm run typecheck
       - run: npm test
 
+      # We redistribute the chart engine inside dist/, so the notices are part
+      # of the artifact. Derived from the build's own module list, which is how
+      # a new transitive dependency gets noticed — an omission here is a licence
+      # problem, not a docs one. Offline: reads node_modules, not the network.
+      - name: Third-party notices are current
+        run: npm run notices --workspace packages/react-native -- --check
+
       # The end-to-end run drives a real browser against the deployed Graph
       # API, so it fails on a network blip rather than a code change. Kept
       # non-blocking; run it locally when touching the element or the wrapper.

--- a/.github/workflows/renderer_drift.yml
+++ b/.github/workflows/renderer_drift.yml
@@ -1,0 +1,82 @@
+name: Renderer drift
+
+# The React Native package does not reimplement the chart: its
+# `src/option-builder.js` is copied verbatim out of the web renderer that Terra
+# serves, by `npm run extract`. Nothing stops the web renderer changing
+# afterwards, and when it does the native package quietly keeps drawing the old
+# chart — same graph, different code, no error anywhere.
+#
+# The two tests that would catch this skip in CI, because they want a terra-v6
+# checkout beside the repo. This does not: it re-extracts from the deployed
+# renderer and fails if the result differs from what is committed.
+#
+# Scheduled rather than per-PR, because it depends on production being
+# reachable, and a network blip must not block an unrelated pull request.
+
+on:
+  schedule:
+    # Weekday mornings, UTC. Drift is not urgent enough to page anyone; it is
+    # only bad if it goes unnoticed for a release.
+    - cron: "0 7 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # An issue is the point of this job. A red scheduled run notifies nobody.
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+
+      - name: Re-extract from the deployed renderer
+        id: extract
+        working-directory: packages/react-native
+        run: npm run extract
+
+      - name: Compare with what we ship
+        id: diff
+        run: |
+          if git diff --quiet -- packages/react-native/src/option-builder.js; then
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            echo "The bundled chart code matches the deployed renderer."
+          else
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'diff<<DIFF_EOF'
+              git diff --unified=3 -- packages/react-native/src/option-builder.js | head -c 55000
+              echo
+              echo 'DIFF_EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report
+        if: steps.diff.outputs.drifted == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIFF: ${{ steps.diff.outputs.diff }}
+        run: |
+          TITLE="Renderer drift: the React Native chart code is behind the deployed renderer"
+          # One open issue, updated — not a new one every weekday morning.
+          EXISTING=$(gh issue list --state open --search "in:title \"Renderer drift\"" --json number --jq '.[0].number // empty')
+          BODY=$(printf '%s\n\n```diff\n%s\n```\n\n%s\n' \
+            "\`npm run extract\` against the deployed renderer no longer reproduces the committed \`packages/react-native/src/option-builder.js\`, so the published React Native package is drawing a different chart from the web." \
+            "$DIFF" \
+            "To resolve: run \`npm run extract\` in \`packages/react-native\`, review the diff, run \`npm test\`, and release. Run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID).")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi
+
+      - name: Fail on drift
+        if: steps.diff.outputs.drifted == 'true'
+        run: |
+          echo "::error::The React Native package's chart code no longer matches the deployed renderer. See the issue this run opened." >&2
+          exit 1

--- a/packages/react-native/THIRD-PARTY-NOTICES.md
+++ b/packages/react-native/THIRD-PARTY-NOTICES.md
@@ -1,15 +1,268 @@
 # Third-party notices
 
 `@tryterra/graphs-react-native` bundles its chart engine into `dist/` rather than
-resolving it from the host app. That makes the following projects part of the
-published artifact, and their licences are reproduced here in full as those
-licences require.
+resolving it from the host app. That makes the projects below part of the published
+artifact, so their licences are reproduced here in full, as those licences require.
+
+Generated from the build's own module list by `npm run notices` — do not edit by hand.
+
+Packages bundled: 5.
+
+## @wuba/react-native-echarts 3.1.1
+
+<http://github.com/wuba/react-native-echarts#readme>
+
+> **Licence declaration conflict (upstream).** `package.json` declares `MIT`,
+> while the shipped `LICENSE` is `Apache-2.0`. We redistribute this
+> package unmodified and comply with the terms of the file it ships, reproduced below,
+> which are the more demanding of the two. Reported here rather than resolved silently.
+
+```
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+
+
+
+========================================================================
+This product bundles various third-party components under other open source licenses.
+This section summarizes those components and their licenses. See licenses/
+for text of these licenses.
+
+BSD 3-Clause
+--------------------------------------
+
+src/utils/platform.ts
+src/SVGCore.ts
+```
+
+---
+
+## @xmldom/xmldom 0.8.14
+
+<https://github.com/xmldom/xmldom>
+
+Licence: `MIT`.
+
+```
+Copyright 2019 - present Christopher J. Brody and other contributors, as listed in: https://github.com/xmldom/xmldom/graphs/contributors
+Copyright 2012 - 2017 @jindw <jindw@xidea.org> and other contributors, as listed in: https://github.com/jindw/xmldom/graphs/contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+---
 
 ## echarts 5.5.1
 
-Declared licence: `Apache-2.0`.
-
 <https://echarts.apache.org>
+
+Licence: `Apache-2.0`.
 
 ### NOTICE
 
@@ -247,9 +500,32 @@ See `/licenses/LICENSE-d3` for details of the license.
 
 ---
 
+## tslib 2.3.0
+
+<https://www.typescriptlang.org/>
+
+Licence: `0BSD`.
+
+```
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+```
+
+---
+
 ## zrender 5.6.0
 
-Declared licence: `BSD-3-Clause`.
+Licence: `BSD-3-Clause`.
 
 ```
 BSD 3-Clause License
@@ -281,257 +557,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```
-
----
-
-## @wuba/react-native-echarts 3.1.1
-
-Declared licence: `MIT`.
-
-<http://github.com/wuba/react-native-echarts#readme>
-
-```
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-
-
-
-
-========================================================================
-This product bundles various third-party components under other open source licenses.
-This section summarizes those components and their licenses. See licenses/
-for text of these licenses.
-
-BSD 3-Clause
---------------------------------------
-
-src/utils/platform.ts
-src/SVGCore.ts
-```
-
----
-
-## tslib 2.3.0
-
-Declared licence: `0BSD`.
-
-<https://www.typescriptlang.org/>
-
-```
-Copyright (c) Microsoft Corporation.
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
 ```
 
 ---

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -44,13 +44,15 @@
   },
   "files": [
     "dist",
+    "!dist/metafile-*.json",
     "README.md",
     "THIRD-PARTY-NOTICES.md"
   ],
   "scripts": {
     "extract": "node scripts/extract-option-builder.mjs",
     "build": "tsup",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "notices": "node scripts/generate-notices.mjs"
   },
   "peerDependencies": {
     "@shopify/react-native-skia": "*",

--- a/packages/react-native/scripts/generate-notices.mjs
+++ b/packages/react-native/scripts/generate-notices.mjs
@@ -1,0 +1,163 @@
+/**
+ * Generates THIRD-PARTY-NOTICES.md from what the bundle actually contains.
+ *
+ * This package ships its chart engine inside `dist/` rather than resolving it
+ * from the host app, which makes us a redistributor of that code and puts us
+ * under its licences. The notices are therefore part of the published artifact,
+ * not documentation.
+ *
+ * The package list is read from esbuild's metafile — every module that ended up
+ * in the bundle — rather than from a hand-kept list, so a new transitive
+ * dependency cannot slip in unnoticed.
+ *
+ *   npm run build     # writes dist/metafile-esm.json
+ *   npm run notices   # rewrites THIRD-PARTY-NOTICES.md
+ *
+ * `npm run notices -- --check` verifies the file is current without writing,
+ * which is what CI runs.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG = path.join(HERE, "..");
+const METAFILE = path.join(PKG, "dist", "metafile-esm.json");
+const OUT = path.join(PKG, "THIRD-PARTY-NOTICES.md");
+const CHECK = process.argv.includes("--check");
+
+/** Every node_modules package that contributed a module to the bundle. */
+function bundledPackages(metafile) {
+  const names = new Set();
+  for (const input of Object.keys(metafile.inputs)) {
+    // "../../node_modules/@wuba/react-native-echarts/lib/..." -> "@wuba/react-native-echarts"
+    const at = input.lastIndexOf("node_modules/");
+    if (at < 0) continue;
+    const rest = input.slice(at + "node_modules/".length).split("/");
+    names.add(rest[0].startsWith("@") ? `${rest[0]}/${rest[1]}` : rest[0]);
+  }
+  return [...names].sort();
+}
+
+/** Resolve a package directory by walking up from here, as Node would. */
+function resolvePackage(name) {
+  let dir = PKG;
+  for (;;) {
+    const candidate = path.join(dir, "node_modules", name);
+    if (fs.existsSync(path.join(candidate, "package.json"))) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+const LICENCE_FILES = ["LICENSE", "LICENSE.md", "LICENSE.txt", "LICENCE", "COPYING"];
+
+/**
+ * The licence a text actually is, independent of what package.json claims.
+ * Used only to surface disagreements — not to decide anything on our behalf.
+ */
+function identify(text) {
+  const head = text.slice(0, 2500);
+  if (/Apache License\s*\n?\s*Version 2\.0/i.test(head)) return "Apache-2.0";
+  if (/\bBSD\b.*3-Clause|Redistributions in binary form/i.test(head) && /\bBSD\b/i.test(head)) return "BSD-3-Clause";
+  // 0BSD and ISC share this wording; the two are told apart only by whether a
+  // copyright line is retained, which is not worth guessing at.
+  if (/Permission to use, copy, modify, and\/or distribute this software/i.test(head)) return "0BSD/ISC";
+  if (/Permission is hereby granted, free of charge/i.test(head)) return "MIT";
+  return null;
+}
+
+/** Does the declared licence agree with what the shipped file appears to be? */
+function agrees(declared, actual) {
+  if (!declared || !actual) return true;
+  if (declared === actual) return true;
+  return actual === "0BSD/ISC" && (declared === "0BSD" || declared === "ISC");
+}
+
+const metafile = JSON.parse(fs.readFileSync(METAFILE, "utf8"));
+const names = bundledPackages(metafile);
+if (!names.length) throw new Error("metafile lists no bundled packages — did the build run?");
+
+const parts = [
+  "# Third-party notices",
+  "",
+  "`@tryterra/graphs-react-native` bundles its chart engine into `dist/` rather than",
+  "resolving it from the host app. That makes the projects below part of the published",
+  "artifact, so their licences are reproduced here in full, as those licences require.",
+  "",
+  "Generated from the build's own module list by `npm run notices` — do not edit by hand.",
+  "",
+  `Packages bundled: ${names.length}.`,
+  "",
+];
+
+const problems = [];
+
+for (const name of names) {
+  const dir = resolvePackage(name);
+  if (!dir) {
+    problems.push(`${name}: bundled but not resolvable from node_modules`);
+    continue;
+  }
+
+  const meta = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+  const declared = typeof meta.license === "string" ? meta.license : meta.license?.type || null;
+
+  const licenceFile = LICENCE_FILES.map((f) => path.join(dir, f)).find((p) => fs.existsSync(p));
+  const text = licenceFile ? fs.readFileSync(licenceFile, "utf8").trim() : null;
+  const actual = text ? identify(text) : null;
+
+  parts.push(`## ${name} ${meta.version}`, "");
+  if (meta.homepage) parts.push(`<${meta.homepage}>`, "");
+
+  // A package whose package.json and LICENSE file disagree is an upstream defect,
+  // and silently picking one would misstate the terms we redistribute under. Say
+  // both, and say which we comply with.
+  if (!agrees(declared, actual)) {
+    parts.push(
+      `> **Licence declaration conflict (upstream).** \`package.json\` declares \`${declared}\`,`,
+      `> while the shipped \`${path.basename(licenceFile)}\` is \`${actual}\`. We redistribute this`,
+      `> package unmodified and comply with the terms of the file it ships, reproduced below,`,
+      `> which are the more demanding of the two. Reported here rather than resolved silently.`,
+      "",
+    );
+    problems.push(`${name}: package.json says ${declared}, LICENSE file is ${actual}`);
+  } else {
+    parts.push(`Licence: \`${declared ?? actual ?? "see below"}\`.`, "");
+  }
+
+  const notice = path.join(dir, "NOTICE");
+  if (fs.existsSync(notice)) {
+    // Apache-2.0 s4(d): a NOTICE file must travel with redistributions.
+    parts.push("### NOTICE", "", "```", fs.readFileSync(notice, "utf8").trim(), "```", "");
+  }
+
+  if (text) {
+    parts.push("```", text, "```", "");
+  } else {
+    parts.push(
+      `_No licence file is shipped in the package; \`${declared ?? "unknown"}\` is declared in its package.json._`,
+      "",
+    );
+    problems.push(`${name}: no licence file shipped`);
+  }
+
+  parts.push("---", "");
+}
+
+const rendered = parts.join("\n");
+
+if (CHECK) {
+  const current = fs.existsSync(OUT) ? fs.readFileSync(OUT, "utf8") : "";
+  if (current !== rendered) {
+    console.error("THIRD-PARTY-NOTICES.md is out of date. Run `npm run notices` and commit the result.");
+    process.exit(1);
+  }
+  console.log(`notices are current (${names.length} bundled packages)`);
+} else {
+  fs.writeFileSync(OUT, rendered);
+  console.log(`wrote THIRD-PARTY-NOTICES.md (${names.length} bundled packages)`);
+}
+
+for (const p of problems) console.warn(`  note: ${p}`);

--- a/packages/react-native/tsup.config.ts
+++ b/packages/react-native/tsup.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   dts: true,
   clean: true,
   target: "es2020",
+  // Lists every module that ended up in the bundle. `npm run notices` reads it
+  // so the licence file is derived from what we actually redistribute, rather
+  // than from a list someone has to remember to update.
+  metafile: true,
   // The chart engine ships *inside* this package. Bundling it is load-bearing,
   // not a size preference — see the comment at the top of src/index.tsx. The
   // short version: it is the only way to get correct tslib interop under Metro


### PR DESCRIPTION
Two gaps that only surface long after they open.

## Renderer drift

The React Native package doesn't reimplement the chart — `src/option-builder.js` is copied verbatim out of the renderer Terra serves. Nothing stopped the web renderer moving on afterwards, leaving the native package quietly drawing the old chart, with no error anywhere. The two tests that would catch this **skip in CI**, because they want a terra-v6 checkout beside the repo.

`renderer_drift.yml` re-extracts from the *deployed* renderer and opens an issue when the result differs from what's committed.

- **Scheduled, not per-PR** — it depends on production being reachable, and a network blip must not block an unrelated pull request.
- **Files an issue** rather than only going red, because nobody watches scheduled runs. One issue, commented on, not a new one every weekday.
- **Verified both ways**: reports in-sync after a real extract, and drifted once the output is altered. Ran it against production today — **no drift**, the published package matches what the web serves.

## Licence notices

They were hand-written, and wrong in two ways:

- They claimed `@wuba/react-native-echarts` is **MIT** (its package.json says so) while reproducing the **Apache-2.0** text its `LICENSE` actually ships — with nothing explaining the contradiction.
- They **omitted `@xmldom/xmldom`** entirely, which we redistribute via @wuba's SVG painter.

Now generated by `npm run notices` from **esbuild's metafile**, so the list is whatever the bundle actually contains rather than what someone remembered — which is exactly how the missing package was found. CI runs `--check` and fails if the file is stale.

Where a package's package.json and LICENSE disagree, the notices **say so** instead of silently picking one, and state that we redistribute unmodified and comply with the file it ships. That's a fact about upstream worth surfacing, not something to resolve on their behalf.

The metafile is excluded from the published tarball — it would otherwise have added 389 kB to every install.

Nothing here changes the published package's behaviour.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tryterra/codesmith/terra-graphs/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789892186&installation_model_id=431345&pr_number=9&repository=tryterra%2Fterra-graphs&return_to=https%3A%2F%2Fgithub.com%2Ftryterra%2Fterra-graphs%2Fpull%2F9&signature=c928c6ec35d938de485ba2c6d1bc8db80ef3b990201b57926613fe03bc4fb430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->