### PR TITLE
ci: release without writing to a protected main

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -25,9 +25,9 @@ on:
           - "@tryterra/graphs-react"
           - "@tryterra/graphs-react-native"
       release-type:
-        description: "as-is (publish the version in package.json) | patch | minor | major | prepatch | preminor | premajor | prerelease"
+        description: "as-is publishes the version already on main — the normal path, since main is protected and a bump cannot be pushed back. patch | minor | major | prerelease publish a version that will exist only on the runner."
         required: true
-        default: patch
+        default: as-is
 
 jobs:
   release:
@@ -35,7 +35,7 @@ jobs:
     permissions:
       # Mint the OIDC token npm exchanges for a short-lived publish credential.
       id-token: write
-      # The release commit and tag are pushed from here.
+      # Pushing the release tag. The branch is protected and never written to.
       contents: write
     steps:
       - uses: actions/checkout@v4
@@ -130,14 +130,23 @@ jobs:
             exit 1
           fi
 
-      - name: Commit and tag
+      # main is protected and Actions cannot be granted a bypass, so this job
+      # never writes to the branch — only the tag, which a branch ruleset does
+      # not govern. The version bump therefore has to be on main *before* the
+      # release runs, which is what `as-is` is for: land the bump in a reviewed
+      # PR, then release exactly what was reviewed.
+      - name: Tag
         run: |
-          git add CHANGELOG.md "${{ steps.pkg.outputs.dir }}/package.json" package-lock.json
-          # An as-is release bumps nothing, so there may be nothing staged —
-          # that must not abort the tag.
-          git diff --cached --quiet || git commit -m "chore: release ${{ env.TAG }}"
           git tag "${{ env.TAG }}"
-          git push origin HEAD --tags
+          git push origin "refs/tags/${{ env.TAG }}"
+
+      # A bump release-type computes a version that only ever existed on the
+      # runner: the package is published and tagged, but main still says the old
+      # number. Say so loudly rather than leaving someone to find it later.
+      - name: Warn that main is behind
+        if: inputs.release-type != 'as-is'
+        run: |
+          echo "::warning::Published ${{ env.TAG }}, but the version bump exists only on this runner — main is protected and this job cannot push to it. Raise a PR setting ${{ steps.pkg.outputs.dir }}/package.json to ${NEW_VERSION#v} and updating CHANGELOG.md. Prefer 'as-is': bump in a PR first, then release what was reviewed."
 
       - id: changelog
         uses: superfaceai/release-changelog-action@v2


### PR DESCRIPTION
`main` now has a ruleset requiring a pull request and the `build` check (see below). A **repo-level ruleset cannot grant the GitHub Actions app a bypass** — the org rejects the actor with `Actor GitHub Actions integration must be part of the ruleset source or owner organization` — so the release job could no longer push its version-bump commit to the branch.

It would have failed at `git push origin HEAD --tags`, **after** publishing to npm. That's the worst place to fail: the irreversible step succeeds and the repo is left disagreeing with the registry.

**The job now pushes only the tag**, which a branch ruleset does not govern, and `as-is` becomes the default release type: land the version bump in a reviewed PR, then release exactly what was reviewed. That's how 1.0.0 shipped anyway.

The bump types (`patch`/`minor`/`major`/`prerelease`) still work and still publish, but the new version then exists only on the runner — so they now emit a warning saying main is behind and exactly what to raise a PR for, rather than leaving someone to discover it.

### The ruleset this responds to

Applied to `terra-graphs` (which had **no protection at all** — main was open to direct pushes, force-pushes and deletion). Modelled on `terra-dashboard-v2`'s:

| Rule | Setting |
| --- | --- |
| Pull request required | 1 approval, no stale dismissal |
| Required status check | `build` |
| Force-push | blocked |
| Deletion | blocked |
| Bypass | Organization admins |

Note the bypass is real: an org admin can still push directly, which I confirmed by accident while testing. Protection here is a guardrail against mistakes, not a control against someone with admin.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tryterra/codesmith/terra-graphs/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789893815&installation_model_id=431345&pr_number=10&repository=tryterra%2Fterra-graphs&return_to=https%3A%2F%2Fgithub.com%2Ftryterra%2Fterra-graphs%2Fpull%2F10&signature=cee50a8dcfd5a4df0a2acbc87909440683cd71b2b474c0b0239c60593d9fbec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->